### PR TITLE
allow module include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.1.2] - 2022-02-21
+
+- Fix error when including module
+- Write comments and fix some typos
+
 ## [0.1.1] - 2022-02-20
 
 - Remove attribute `:pass`

--- a/README.md
+++ b/README.md
@@ -5,23 +5,29 @@ Create random password with ruby. Use `SecureRandom#base64` + few random special
 ## How to install
 
  - install from rubygems
+
 ```
 gem install randpass
 ```
  - download from github with ssh
+
 ```
 git clone git@github.com:alx3dev/randpass \
 cd randpass && bundle install
 ```
  - download from github with https
+
 ```
 git clone https://www.github.com/alx3dev/randpass \
 cd randpass && bundle install
 ```
 
+To build your own gem, run `rake bundle`, and install it locally with `gem install pkg/randpass-0.1.1.gem`
+
 ## How to use:
 
  - use from terminal
+
 ```
 # default 18 characters
 randpass
@@ -31,10 +37,11 @@ randpass
 randpass 30
  => zBv2BXVB/X2WJMqzSE%VRe#Sg!/0_wYpvJC1gyHU
  
- # if you not install from rubygems, you need to run
+ # install from rubygems, or build your own version, otherwise you need to run:
  bin/randpass
 ```
  - use as library
+
 ```ruby
 require 'randpass'
 
@@ -43,4 +50,16 @@ Randpass[20]
 Randpass.randpass 20
  => "0!ZNiAUZCbjo!#hHeX+XX$eAC=!p"
 ```
-Randpass is a module, so you can include/extend it in your class, to call `randpass` method.
+
+Randpass is a module with both class and instance methods `#randpass`, so you can include/extend it in your class.
+
+```ruby
+require 'randpass'
+include Randpass
+
+class MyClass
+  def some_method
+    random_string = randpass 33
+  end
+end
+```

--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ class MyClass
   end
 end
 ```
+
+Tested on:
+ - ruby `2.7.5`
+ - ruby `3.0.3`
+ - ruby `3.1.0-preview1`
+ - jruby `9.3.2.0`

--- a/lib/randpass.rb
+++ b/lib/randpass.rb
@@ -2,7 +2,3 @@
 
 require_relative 'randpass/version'
 require_relative 'randpass/random'
-
-module Randpass
-  class Error < StandardError; end
-end

--- a/lib/randpass/random.rb
+++ b/lib/randpass/random.rb
@@ -2,20 +2,35 @@
 
 require 'securerandom'
 
-# Generate random password with base64 and few random special characters
+# Generate random password with SecureRandom#base64 and a few
+# random special characters. Method #randpass is defined as
+# class and instance method, so you can call it or include it.
+#
+# @note Always shuffle #base64 if it has less than 16 chars, because they end with '=='
 #
 module Randpass
+  #
+  # Random number of times try to add random special character.
+  # Transform to array, shuffle, and join back to string
+  #
+  # @param [Integer] number_of_chars **Required**. Number of password characters.
+  # @return [String]
+  #
+  def randpass(number_of_chars)
+    Randpass[number_of_chars]
+  end
+
   class << self
-    #
-    # Add special characters to base64 random string, and shuffle it
-    # @note Always shuffle #base64 if it has less than 16 chars, because they end with '=='
-    #
-    def [](number_of_chars = 18)
+    # @return [String]
+    def randpass(number_of_chars)
       param = SecureRandom.base64(number_of_chars)
-      rand(5..10).times { param = add_special_chars(param) }
+      rand(5..10).times do
+        param = add_special_chars(param)
+      end
       param.split('').shuffle.join
     end
-    alias randpass []
+
+    alias [] randpass
 
     private
 
@@ -24,6 +39,7 @@ module Randpass
       # bigger number than options - we don't want
       # same number of special chars each time
       count = SecureRandom.random_number 15_000
+
       char = case count
              when 1...1000    then '_'
              when 1000...2000 then '!'
@@ -33,6 +49,7 @@ module Randpass
              when 6000...7000 then '?'
              else return param
              end
+
       param[rand(param.size)] = char
       param
     end

--- a/lib/randpass/version.rb
+++ b/lib/randpass/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module Randpass
-  VERSION = '0.1.1'
+  # gem version
+  VERSION = '0.1.2'
 end

--- a/randpass.gemspec
+++ b/randpass.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
                 README.md
                 randpass.gemspec]
 
-  s.required_ruby_version = '>= 2.7', '< 3.2'
+  s.required_ruby_version = '>= 2.6', '< 3.2'
 
   s.add_development_dependency 'bundler', '~> 2.3'
   s.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
Define instance method, so we can include Randpass module in other classes. Fix some typos in redme.md and write documentation. Pass rubocop syntax check. Tested on versions: `2.7.5, 3.0.3, 3.1.0-preview1`.